### PR TITLE
Corrected [Tt]reshold to [Tr]hreshold

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Simply declaring the `aptcacherng` class for a node, will apply the class using 
 * LogDir: /var/log/apt-cacher-ng
 * Port: 3142
 * ReportPage: acng-report.html
-* ExTreshold: 4
+* ExThreshold: 4
 
 *All* `apt-cacher-ng` config file directives are available as parameters to the `aptcacherng` class.  For example, to change the directory where `apt-cacher-ng` will store its cache:
 

--- a/data/common.yaml
+++ b/data/common.yaml
@@ -12,7 +12,7 @@ aptcacherng::dontcacherequested: ~
 aptcacherng::dontcacheresolved: ~
 aptcacherng::exabortonproblems: ~
 aptcacherng::exposeorigin: ~
-aptcacherng::extreshold: 4
+aptcacherng::exthreshold: 4
 aptcacherng::fileperms: ~
 aptcacherng::forcemanaged: ~
 aptcacherng::foreground: ~

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -15,7 +15,7 @@ class aptcacherng::config {
   $dontcacheresolved = $aptcacherng::dontcacheresolved
   $exabortonproblems = $aptcacherng::exabortonproblems
   $exposeorigin = $aptcacherng::exposeorigin
-  $extreshold = $aptcacherng::extreshold
+  $exthreshold = $aptcacherng::exthreshold
   $fileperms = $aptcacherng::fileperms
   $forcemanaged = $aptcacherng::forcemanaged
   $foreground = $aptcacherng::foreground

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -78,7 +78,7 @@
 #   backends (.where)
 #   Default: undef
 #
-# [*extreshold*]
+# [*exthreshold*]
 #   Days before considering an unreferenced file expired (to be deleted).
 #   (integer) Default: 4
 #
@@ -314,7 +314,7 @@
 class aptcacherng (
   Optional[Stdlib::Absolutepath] $cachedir,
   Optional[Stdlib::Absolutepath] $logdir,
-  Integer                        $extreshold,
+  Integer                        $exthreshold,
   Integer                        $port,
   String                         $service_ensure,
   Boolean                        $service_enable,

--- a/spec/classes/aptcacherng_init_spec.rb
+++ b/spec/classes/aptcacherng_init_spec.rb
@@ -35,7 +35,7 @@ describe 'aptcacherng', type: :class do
       it { is_expected.to contain_file('/etc/apt-cacher-ng/acng.conf').with_content(%r{^LogDir: \/var\/log\/apt-cacher-ng$}) }
       it { is_expected.to contain_file('/etc/apt-cacher-ng/acng.conf').with_content(%r{^Port: 3142$}) }
       it { is_expected.to contain_file('/etc/apt-cacher-ng/acng.conf').with_content(%r{^ReportPage: acng-report.html$}) }
-      it { is_expected.to contain_file('/etc/apt-cacher-ng/acng.conf').with_content(%r{^ExTreshold: 4$}) }
+      it { is_expected.to contain_file('/etc/apt-cacher-ng/acng.conf').with_content(%r{^ExThreshold: 4$}) }
       it { is_expected.not_to contain_file('/etc/apt-cacher-ng/security.conf') }
     end # with default params
 
@@ -61,7 +61,7 @@ describe 'aptcacherng', type: :class do
           pidfile: '/srv/apt-cacher-ng/pid',
           offlinemode: '0',
           forcemanaged: '1',
-          extreshold: 4,
+          exthreshold: 4,
           exabortonproblems: '30',
           stupidfs: '1',
           forwardbtssoap: '0',
@@ -115,7 +115,7 @@ describe 'aptcacherng', type: :class do
       it { is_expected.to contain_file('/etc/apt-cacher-ng/acng.conf').with_content(%r{^PidFile: #{params_set[:pidfile]}$}) }
       it { is_expected.to contain_file('/etc/apt-cacher-ng/acng.conf').with_content(%r{^OfflineMode: #{params_set[:offlinemode]}$}) }
       it { is_expected.to contain_file('/etc/apt-cacher-ng/acng.conf').with_content(%r{^ForceManaged: #{params_set[:forcemanaged]}$}) }
-      it { is_expected.to contain_file('/etc/apt-cacher-ng/acng.conf').with_content(%r{^ExTreshold: #{params_set[:extreshold]}$}) }
+      it { is_expected.to contain_file('/etc/apt-cacher-ng/acng.conf').with_content(%r{^ExThreshold: #{params_set[:exthreshold]}$}) }
       it { is_expected.to contain_file('/etc/apt-cacher-ng/acng.conf').with_content(%r{^ExAbortOnProblems: #{params_set[:exabortonproblems]}$}) }
       it { is_expected.to contain_file('/etc/apt-cacher-ng/acng.conf').with_content(%r{^StupidFs: #{params_set[:stupidfs]}$}) }
       it { is_expected.to contain_file('/etc/apt-cacher-ng/acng.conf').with_content(%r{^ForwardBtsSoap: #{params_set[:forwardbtssoap]}$}) }

--- a/templates/acng.conf.erb
+++ b/templates/acng.conf.erb
@@ -122,7 +122,7 @@ ForceManaged: <%= @forcemanaged %>
 # Warning: if the value is set too low and particular index files are not
 # available for some days (mirror downtime) there is a risk of deletion of
 # still useful package files.
-ExTreshold: <%= @extreshold %>
+ExThreshold: <%= @exthreshold %>
 
 # Stop expiration when a critical problem appeared. Currently only failed
 # refresh of an index file is considered as critical.


### PR DESCRIPTION
I believe I have found a typo in the module, multiple references are made to treshold but this should be threshold.  Looking at https://help.ubuntu.com/community/Apt-Cacher%20NG

```
Tuning cache

ExThreshold: 4 # days before purgeing
ExStartTradeOff: 500m # Size of local cache, expiration run is suppressed, until limited is surpaced.
``` 

A quick search of the repo found the following entries:

```
shebert@shebert-lnx ~/projects/puppet-aptcacherng (production)$ grep -ri tres
spec/classes/aptcacherng_init_spec.rb:      it { is_expected.to contain_file('/etc/apt-cacher-ng/acng.conf').with_content(%r{^ExTreshold: 4$}) }
spec/classes/aptcacherng_init_spec.rb:          extreshold: 4,
spec/classes/aptcacherng_init_spec.rb:      it { is_expected.to contain_file('/etc/apt-cacher-ng/acng.conf').with_content(%r{^ExTreshold: #{params_set[:extreshold]}$}) }
templates/acng.conf.erb:ExTreshold: <%= @extreshold %>
manifests/init.pp:# [*extreshold*]
manifests/init.pp:  Integer                        $extreshold,
manifests/config.pp:  $extreshold = $aptcacherng::extreshold
README.md:* ExTreshold: 4
data/common.yaml:aptcacherng::extreshold: 4

``` 

I've updated the entries in quesiton.